### PR TITLE
In tests, compare str to str, not str to bytes

### DIFF
--- a/tests/test_nudatus.py
+++ b/tests/test_nudatus.py
@@ -41,7 +41,7 @@ def test_mangle_script():
         script = f.read()
     assert len(script) > 0
     with open('tests/bigscript_mangled.py') as f:
-        real_mangled = f.read().encode('utf-8')
+        real_mangled = f.read()
     assert len(real_mangled) > 0
     mangled = nudatus.mangle(script)
     assert mangled == real_mangled


### PR DESCRIPTION
before:

```
=================================================== FAILURES ====================================================
______________________________________________ test_mangle_script _______________________________________________

    def test_mangle_script():
        """
        Check that mangle returns the expected output
        """
        script = ''
        real_mangled = b''
        with open('tests/bigscript.py') as f:
            script = f.read()
        assert len(script) > 0
        with open('tests/bigscript_mangled.py') as f:
            real_mangled = f.read().encode('utf-8')
        assert len(real_mangled) > 0
        mangled = nudatus.mangle(script)
>       assert mangled == real_mangled
E       assert 'from microbit import *\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nobj = {\n    "key": "val"\n}\n\narr = [\n    \'a\',\n    ...   i.set_pixel(2, 2, 9)\n    if num & 0b00000001:\n        i.set_pixel(3, 2, 9)\n    display.show(i)\n\nshow_num(12)\n' == b'from microbit import *\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nobj = {\n    "key": "val"\n}\n\narr = [\n    \'a\',\n   ...   i.set_pixel(2, 2, 9)\n    if num & 0b00000001:\n        i.set_pixel(3, 2, 9)\n    display.show(i)\n\nshow_num(12)\n'

tests/test_nudatus.py:47: AssertionError
====================================== 1 failed, 7 passed in 0.08 seconds =======================================
```