### PR TITLE
Python 3.12 fixes

### DIFF
--- a/nudatus.py
+++ b/nudatus.py
@@ -10,11 +10,13 @@ https://opensource.org/licenses/MIT
 """
 
 import argparse
+import ast
 import sys
 import token
 import tokenize
 from io import BytesIO
 from tokenize import tokenize as tokenizer
+from tokenize import TokenError
 from typing import List, Optional
 
 _VERSION = (
@@ -47,6 +49,15 @@ def mangle(text: str) -> str:
     last_col = 0
     last_line_text = ""
     open_list_dicts = 0
+
+    # Parsing invalid code via the tokenizer is documented as "undefined".
+    # Python 3.12 sometimes successfully parses invalid code.
+    # To restore behavior before Python 3.12, we raise explicitly
+    # if ast cannot parse this:
+    try:
+        ast.parse(text_bytes)
+    except SyntaxError as e:
+        raise TokenError(e)
 
     # Build tokens from the script
     tokens = tokenizer(buff.readline)

--- a/tests/test_nudatus.py
+++ b/tests/test_nudatus.py
@@ -52,10 +52,10 @@ def test_main_without_file(capfd):
     with mock.patch("sys.argv", ["nudatus"]):
         with pytest.raises(SystemExit) as ex:
             nudatus.main()
-            assert ex.value.code == 1
-            out, err = capfd.readouterr()
-            assert len(out) == 0
-            assert err == "No file specified"
+        assert ex.value.code == 1
+        out, err = capfd.readouterr()
+        assert len(out) == 0
+        assert err.strip() == "No file specified"
 
 
 def test_main_with_file_without_output_file(capfd):
@@ -95,7 +95,7 @@ def test_main_with_bad_script(capfd):
     with pytest.raises(SystemExit) as ex:
         with mock.patch("sys.argv", ["nudatus", "tests/bigscript_bad.py"]):
             nudatus.main()
-        assert ex.value.code == 1
+    assert ex.value.code == 1
     out, err = capfd.readouterr()
     assert len(out) == 0
     assert len(err) > 0


### PR DESCRIPTION

    _________________________ test_main_with_bad_script __________________________

    capfd = <_pytest.capture.CaptureFixture object at 0x7fd822ea7500>

        def test_main_with_bad_script(capfd):
            with pytest.raises(SystemExit) as ex:
                with mock.patch("sys.argv", ["nudatus", "tests/bigscript_bad.py"]):
                    nudatus.main()
    >           assert ex.value.code == 1

    tests/test_nudatus.py:98:
     _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

    self = <ExceptionInfo for raises contextmanager>

        @property
        def value(self) -> E:
            """The exception value."""
    >       assert (
                self._excinfo is not None
            ), ".value can only be used after the context manager exits"
    E       AssertionError: .value can only be used after the context manager exits

    .tox/py312/lib/python3.12/site-packages/_pytest/_code/code.py:558: Assertion Error

This does not make the tests pass, but it gets further.